### PR TITLE
Fix layout headings and Rake tasks

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,7 @@
 
 require "nokogiri"
 require "yaml"
+require "fileutils"
 
 desc "Create a new draft"
 task :draft do
@@ -18,7 +19,7 @@ desc "Publish a draft"
 task :publish do
   draft_files = Dir.glob("_drafts/*.md")
   file = fzf(draft_files, "Select a draft to publish")
-  next if file.empty?
+  next if file.to_s.empty?
 
   filename = File.basename(file)
   new_path = File.join("_posts", "#{now}-#{filename}")
@@ -40,6 +41,7 @@ task :unpublish do
 
   filename = File.basename(file).sub(/^\d{4}-\d{2}-\d{2}-/, "")
   new_path = File.join("_drafts", filename)
+  FileUtils.mkdir_p("_drafts")
 
   File.rename(file, new_path)
   puts "Post unpublished as #{new_path}"
@@ -79,6 +81,7 @@ def write_to_file(dir:, attributes:, layout: "post")
   attributes["date"] = now
   content = YAML.dump(attributes) + "---"
 
+  FileUtils.mkdir_p(dir)
   path = File.join(dir, "#{slug}.md")
   File.write(path, content)
 end

--- a/_layouts/category.html
+++ b/_layouts/category.html
@@ -3,7 +3,7 @@ layout: default
 ---
 
 <div class='post page'>
-  <h1 class='title'>{{ page.title }}</h2>
+  <h1 class='title'>{{ page.title }}</h1>
   <p><small><i>Showing posts tagged with #{{ page.category }}</i></small></p>
 </div>
 

--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -8,7 +8,7 @@ layout: default
       <a href="/notes/">Notes</a> /
     {% endif %}
     {{ page.title }}
-    </h2>
+  </h1>
 
   <div class='content'>
   {{ content }}

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -3,7 +3,7 @@ layout: default
 ---
 
 <div class='post'>
-  <h1 class='title'>{{ page.title }}</h2>
+  <h1 class='title'>{{ page.title }}</h1>
   <p class='meta'>{{ page.date | date_to_string }}</p>
 
   <div class='content'>


### PR DESCRIPTION
## Summary
- ensure missing directories are created when publishing/unpublishing
- handle cancelation in `rake publish`
- fix mismatched headings in layouts

## Testing
- `ruby -c Rakefile`

------
https://chatgpt.com/codex/tasks/task_e_68408e92a48083329f030b76c2bce2dc